### PR TITLE
Chore: start 3000 port로 script 변경

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "start": "vite",
+    "start": "vite --host 0.0.0.0 --port 3000",
     "build": "tsc && vite build",
     "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"


### PR DESCRIPTION
## 개요
start 3000 port로 script 변경
## 작업 사항
Vite 기본 포트 5173 설정을 매번 포트 변경하기 번거로울 것 같아 3000번으로 스크립트 변경하였습니다.
## 개선점