### PR TITLE
Refactor: 포트폴리오 작성 단계 UX 개선, 전반적 UI 다크모드 고도화

### DIFF
--- a/src/Hook/useOnChangeInput.tsx
+++ b/src/Hook/useOnChangeInput.tsx
@@ -5,21 +5,14 @@ interface useOnChangeInputProps {
   setRecoilState: SetterOrUpdater<string>;
   inputValue?: string;
   validator?: (value: string) => (string | boolean)[];
-  setIsCheckboxChecked?: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-const useOnChangeInput = ({
-  setRecoilState,
-  inputValue,
-  validator,
-  setIsCheckboxChecked,
-}: useOnChangeInputProps) => {
+const useOnChangeInput = ({ setRecoilState, inputValue, validator }: useOnChangeInputProps) => {
   const [isInvalid, setIsInvalid] = useState(true);
   const [errorMessage, setErrorMessage] = useState<string | boolean>('');
 
   const onChangeInput = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     setRecoilState(() => e.target.value);
-    setIsCheckboxChecked && setIsCheckboxChecked(false);
   };
 
   useEffect(() => {

--- a/src/Hook/useOnChangeInput.tsx
+++ b/src/Hook/useOnChangeInput.tsx
@@ -5,13 +5,25 @@ interface useOnChangeInputProps {
   setRecoilState: SetterOrUpdater<string>;
   inputValue?: string;
   validator?: (value: string) => (string | boolean)[];
+  REGEX?: RegExp;
 }
 
-const useOnChangeInput = ({ setRecoilState, inputValue, validator }: useOnChangeInputProps) => {
+const useOnChangeInput = ({
+  setRecoilState,
+  inputValue,
+  validator,
+  REGEX,
+}: useOnChangeInputProps) => {
   const [isInvalid, setIsInvalid] = useState(true);
   const [errorMessage, setErrorMessage] = useState<string | boolean>('');
 
   const onChangeInput = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    if (REGEX) {
+      const RegExInputValue = e.target.value.replace(REGEX, '');
+      setRecoilState(RegExInputValue);
+      return;
+    }
+
     setRecoilState(() => e.target.value);
   };
 

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -6,7 +6,7 @@ interface ModalProps {
   subText?: string;
   mainButtonText: string;
   subButtonText?: string;
-  deletePost?: (id: number) => Promise<void>;
+  deletePost?: ((id: number) => Promise<void>) | ((id: number) => void);
   onClose: () => void;
   onCloseKakaoModal?: () => void;
   selectedId?: number | null;

--- a/src/components/common/SnackbarPopup.tsx
+++ b/src/components/common/SnackbarPopup.tsx
@@ -45,7 +45,7 @@ const StSnackbar = styled.div<{ type: string }>`
   position: fixed;
   display: flex;
   align-items: center;
-  z-index: 1;
+  z-index: 999;
   right: 2%;
   bottom: 30px;
   min-width: 250px;

--- a/src/components/common/createPortfolio/SelectDropdown.tsx
+++ b/src/components/common/createPortfolio/SelectDropdown.tsx
@@ -4,6 +4,8 @@ import { IoIosArrowDown } from 'react-icons/io';
 import { IoIosArrowUp } from 'react-icons/io';
 import { StInputLabel } from '@src/style/common/createStepStyles';
 import useCloseDropdown from '@src/Hook/useCloseDropdown';
+import { useRecoilValue } from 'recoil';
+import { isDarkModeState } from '@src/states/darkModeState';
 
 interface SelectDropdownProps {
   dropdownOptions: string[];
@@ -15,6 +17,7 @@ interface SelectDropdownProps {
 }
 
 const SelectDropdown = (props: SelectDropdownProps) => {
+  const isDarkMode = useRecoilValue<boolean>(isDarkModeState);
   const [isDropdownOpen, setIsDropdownOpen] = useState<boolean>(false);
   const { dropdownRef, onClickOutside } = useCloseDropdown({ isDropdownOpen, setIsDropdownOpen });
 
@@ -55,9 +58,13 @@ const SelectDropdown = (props: SelectDropdownProps) => {
       </StSelectBar>
 
       {isDropdownOpen && (
-        <StDropdownUnorderedList ref={dropdownRef}>
+        <StDropdownUnorderedList ref={dropdownRef} isdarkmode={`${isDarkMode}`}>
           {props.dropdownOptions.map((option: string, index: number) => (
-            <StDropdownList key={index} onClick={() => onClickOption(option)}>
+            <StDropdownList
+              key={index}
+              onClick={() => onClickOption(option)}
+              isdarkmode={`${isDarkMode}`}
+            >
               {option}
             </StDropdownList>
           ))}
@@ -102,24 +109,26 @@ const StSelectValue = styled.div<{ ispersonalinfo: string; isselected: string }>
   color: ${({ isselected }) => !(isselected.length > 1) && '#b5b5b5'};
 `;
 
-const StDropdownUnorderedList = styled.ul`
+const StDropdownUnorderedList = styled.ul<{ isdarkmode: string }>`
   position: absolute;
   width: 100%;
   max-height: 170px;
   overflow-y: auto;
   margin-top: 5px;
-  background-color: white;
+  background-color: ${({ theme, isdarkmode }) =>
+    isdarkmode === 'true' ? theme.color.darkModeGray : 'white'};
   border: 1px solid gray;
   border-radius: 7px;
   margin-bottom: 20px;
 `;
 
-const StDropdownList = styled.li`
+const StDropdownList = styled.li<{ isdarkmode: string }>`
   cursor: pointer;
   padding: 9px 20px;
 
   &:hover {
-    background-color: ${({ theme }) => theme.color.lightGray};
+    background-color: ${({ theme, isdarkmode }) =>
+      isdarkmode === 'true' ? 'black' : theme.color.lightGray};
   }
 
   &:first-child {

--- a/src/components/common/createPortfolio/SelectDropdown.tsx
+++ b/src/components/common/createPortfolio/SelectDropdown.tsx
@@ -1,0 +1,144 @@
+import { useEffect, useState } from 'react';
+import { styled } from 'styled-components';
+import { IoIosArrowDown } from 'react-icons/io';
+import { IoIosArrowUp } from 'react-icons/io';
+import { StInputLabel } from '@src/style/common/createStepStyles';
+import useCloseDropdown from '@src/Hook/useCloseDropdown';
+
+interface SelectDropdownProps {
+  dropdownOptions: string[];
+  selectBarDefaultText: string;
+  selectedOption: string;
+  setSelectedOption: React.Dispatch<React.SetStateAction<string>>;
+  label: string;
+  isPersonalInfo?: boolean;
+}
+
+const SelectDropdown = (props: SelectDropdownProps) => {
+  const [isDropdownOpen, setIsDropdownOpen] = useState<boolean>(false);
+  const { dropdownRef, onClickOutside } = useCloseDropdown({ isDropdownOpen, setIsDropdownOpen });
+
+  const onClickSelectBar = () => {
+    setIsDropdownOpen(!isDropdownOpen);
+  };
+
+  const onClickOption = (option: string) => {
+    props.setSelectedOption(option);
+    setIsDropdownOpen(false);
+  };
+
+  useEffect(() => {
+    document.addEventListener('mousedown', onClickOutside);
+
+    return () => {
+      document.removeEventListener('mousedown', onClickOutside);
+    };
+  }, [isDropdownOpen, dropdownRef.current]);
+
+  return (
+    <StDropdownContainer>
+      <StSelectBar
+        onClick={onClickSelectBar}
+        isclicked={`${isDropdownOpen}`}
+        ispersonalinfo={`${props.isPersonalInfo}`}
+      >
+        <StTextContainer>
+          <StInputLabel>{props.label}</StInputLabel>
+          <StSelectValue
+            ispersonalinfo={`${props.isPersonalInfo}`}
+            isselected={props.selectedOption}
+          >
+            {props.selectedOption || props.selectBarDefaultText}
+          </StSelectValue>
+        </StTextContainer>
+        {isDropdownOpen ? <StArrowUpIcon /> : <StArrowDownIcon />}
+      </StSelectBar>
+
+      {isDropdownOpen && (
+        <StDropdownUnorderedList ref={dropdownRef}>
+          {props.dropdownOptions.map((option: string, index: number) => (
+            <StDropdownList key={index} onClick={() => onClickOption(option)}>
+              {option}
+            </StDropdownList>
+          ))}
+        </StDropdownUnorderedList>
+      )}
+    </StDropdownContainer>
+  );
+};
+
+const StDropdownContainer = styled.div`
+  width: 100%;
+  position: relative;
+`;
+
+const StSelectBar = styled.div<{ isclicked: string; ispersonalinfo: string }>`
+  outline: ${({ isclicked }) => (isclicked === 'true' ? '2px solid' : '1px solid')};
+  outline-color: ${({ ispersonalinfo }) => (ispersonalinfo === 'true' ? 'gray' : 'black')};
+  border-radius: 7px;
+  width: 100%;
+  height: 50px;
+  display: flex;
+  padding: 35px 20px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  box-sizing: border-box;
+
+  cursor: pointer;
+`;
+
+const StTextContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  gap: 5px;
+`;
+
+const StSelectValue = styled.div<{ ispersonalinfo: string; isselected: string }>`
+  padding-top: 2px;
+  font-weight: ${({ ispersonalinfo, isselected }) =>
+    ispersonalinfo === 'true' ? (isselected.length > 1 ? '600' : '400') : '800'};
+  color: ${({ isselected }) => !(isselected.length > 1) && '#b5b5b5'};
+`;
+
+const StDropdownUnorderedList = styled.ul`
+  position: absolute;
+  width: 100%;
+  max-height: 170px;
+  overflow-y: auto;
+  margin-top: 5px;
+  background-color: white;
+  border: 1px solid gray;
+  border-radius: 7px;
+  margin-bottom: 20px;
+`;
+
+const StDropdownList = styled.li`
+  cursor: pointer;
+  padding: 9px 20px;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.color.lightGray};
+  }
+
+  &:first-child {
+    padding-top: 17px;
+    border-radius: 7px 7px 0 0;
+  }
+
+  &:last-child {
+    border-radius: 0 0 7px 7px;
+    padding-bottom: 17px;
+  }
+`;
+
+const StArrowDownIcon = styled(IoIosArrowDown)`
+  font-size: 30px;
+`;
+
+const StArrowUpIcon = styled(IoIosArrowUp)`
+  font-size: 30px;
+`;
+
+export default SelectDropdown;

--- a/src/components/common/createPortfolio/validator.ts
+++ b/src/components/common/createPortfolio/validator.ts
@@ -16,6 +16,10 @@ export const TELEPHONE_REGEX = {
   US_NUMBER: /^(\d{3})(\d{3})(\d{4})$/,
 };
 
+export const LINK_REGEX = /[^a-zA-Z0-9 !/@#$%^&*(),.?":{}|<>_-]+/g;
+
+export const GITHUB_ID_REGEX = /[^A-Za-z0-9-]/g;
+
 export const validateTitle = (value: string) => {
   const isInvalidTitle = value.length < 5;
   return [isInvalidTitle, isInvalidTitle && ERROR_MESSAGE.TITLE_UNDER_5];

--- a/src/components/common/createPortfolio/validator.ts
+++ b/src/components/common/createPortfolio/validator.ts
@@ -4,6 +4,13 @@ const ERROR_MESSAGE = {
   EXPERIENCE: '10자 이상 입력해주세요.',
 };
 
+export const TELEPHONE_REGEX = {
+  ONLY_NUMBER: /[^0-9]/g,
+  KOR_FIRST_THREE_NUMBER: /^(\d{3})(\d{4})(\d{4})$/,
+  KOR_FIRST_TWO_NUMBER: /^(\d{2})(\d{4})(\d{4})$/,
+  US_NUMBER: /^(\d{3})(\d{3})(\d{4})$/,
+};
+
 export const validateTitle = (value: string) => {
   const isInvalidTitle = value.length < 5;
   return [isInvalidTitle, isInvalidTitle && ERROR_MESSAGE.TITLE_UNDER_5];

--- a/src/components/common/createPortfolio/validator.ts
+++ b/src/components/common/createPortfolio/validator.ts
@@ -4,6 +4,11 @@ const ERROR_MESSAGE = {
   EXPERIENCE: '10자 이상 입력해주세요.',
 };
 
+export const EMAIL_REGEX = {
+  ID: /[^A-Za-z0-9_.-]/g,
+  ALL: /^(([^<>()\[\].,;:\s@"]+(\.[^<>()\[\].,;:\s@"]+)*)|(".+"))@(([^<>()[\].,;:\s@"]+\.)+[^<>()[\].,;:\s@"]{2,})$/,
+};
+
 export const TELEPHONE_REGEX = {
   ONLY_NUMBER: /[^0-9]/g,
   KOR_FIRST_THREE_NUMBER: /^(\d{3})(\d{4})(\d{4})$/,
@@ -17,9 +22,7 @@ export const validateTitle = (value: string) => {
 };
 
 export const validateEmail = (value: string) => {
-  const EMAIL_REGEX =
-    /^(([^<>()\[\].,;:\s@"]+(\.[^<>()\[\].,;:\s@"]+)*)|(".+"))@(([^<>()[\].,;:\s@"]+\.)+[^<>()[\].,;:\s@"]{2,})$/;
-  const isInvalid = !EMAIL_REGEX.test(value);
+  const isInvalid = !EMAIL_REGEX.ALL.test(value);
   return [isInvalid, isInvalid && ERROR_MESSAGE.EMAIL];
 };
 

--- a/src/components/createPortfolio/CategorySelectDropdown.tsx
+++ b/src/components/createPortfolio/CategorySelectDropdown.tsx
@@ -4,6 +4,8 @@ import { IoIosArrowDown } from 'react-icons/io';
 import { IoIosArrowUp } from 'react-icons/io';
 import { StInputLabel } from '../../style/common/createStepStyles';
 import useCloseDropdown from '@src/Hook/useCloseDropdown';
+import { useRecoilValue } from 'recoil';
+import { isDarkModeState } from '@src/states/darkModeState';
 
 interface CategorySelectDropdownProps {
   dropdownOptions: string[];
@@ -19,6 +21,7 @@ const CategorySelectDropdown = ({
   setSelectedOption,
 }: CategorySelectDropdownProps) => {
   const [isDropdownOpen, setIsDropdownOpen] = useState<boolean>(false);
+  const isDarkMode = useRecoilValue<boolean>(isDarkModeState);
 
   const { dropdownRef, onClickOutside } = useCloseDropdown({ isDropdownOpen, setIsDropdownOpen });
 
@@ -50,9 +53,13 @@ const CategorySelectDropdown = ({
       </StSelectBar>
 
       {isDropdownOpen && (
-        <StDropdownUnorderedList ref={dropdownRef}>
+        <StDropdownUnorderedList ref={dropdownRef} isdarkmode={`${isDarkMode}`}>
           {dropdownOptions.map((option: string, index: number) => (
-            <StDropdownList key={index} onClick={() => onClickOption(option)}>
+            <StDropdownList
+              key={index}
+              onClick={() => onClickOption(option)}
+              isdarkmode={`${isDarkMode}`}
+            >
               {option}
             </StDropdownList>
           ))}
@@ -94,21 +101,23 @@ const StSelectValue = styled.div`
   font-weight: 800;
 `;
 
-const StDropdownUnorderedList = styled.ul`
+const StDropdownUnorderedList = styled.ul<{ isdarkmode: string }>`
   position: absolute;
   width: 100%;
   margin-top: 5px;
-  background-color: white;
+  background-color: ${({ theme, isdarkmode }) =>
+    isdarkmode === 'true' ? theme.color.darkModeGray : 'white'};
   border: 1px solid gray;
   border-radius: 7px;
 `;
 
-const StDropdownList = styled.li`
+const StDropdownList = styled.li<{ isdarkmode: string }>`
   cursor: pointer;
   padding: 9px 20px;
 
   &:hover {
-    background-color: ${({ theme }) => theme.color.lightGray};
+    background-color: ${({ theme, isdarkmode }) =>
+      isdarkmode === 'true' ? 'black' : theme.color.lightGray};
   }
 
   &:first-child {

--- a/src/components/createPortfolio/EmailForm.tsx
+++ b/src/components/createPortfolio/EmailForm.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useRecoilState, useSetRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import { styled } from 'styled-components';
 import { createEmailDomainState, createEmailIdState, createEmailState } from '@src/states';
 import { IoIosArrowDown } from 'react-icons/io';
@@ -10,6 +10,7 @@ import useCloseDropdown from '@src/Hook/useCloseDropdown';
 import useDecodeJWT from '@src/Hook/useDecodeJWT';
 import { StInputLabel } from '@src/style/common/createStepStyles';
 import { EMAIL_REGEX } from '../common/createPortfolio/validator';
+import { isDarkModeState } from '@src/states/darkModeState';
 
 interface EmailFormProps {
   isInvalidEmail: boolean;
@@ -18,6 +19,7 @@ interface EmailFormProps {
 
 const EmailForm = ({ isInvalidEmail, errorMessage }: EmailFormProps) => {
   const setEmail = useSetRecoilState<string>(createEmailState);
+  const isDarkMode = useRecoilValue<boolean>(isDarkModeState);
   const [emailIdValue, setEmailIdValue] = useRecoilState<string>(createEmailIdState);
   const [emailDomainValue, setEmailDomainValue] = useRecoilState<string>(createEmailDomainState);
   const [isDropdownOpen, setIsDropdownOpen] = useState<boolean>(false);
@@ -125,9 +127,13 @@ const EmailForm = ({ isInvalidEmail, errorMessage }: EmailFormProps) => {
               </StemailDomain>
             )}
             {isDropdownOpen && (
-              <StDropdownUnorderedList ref={dropdownRef}>
+              <StDropdownUnorderedList ref={dropdownRef} isdarkmode={`${isDarkMode}`}>
                 {emailDomainList.map((domain, index) => (
-                  <StDropdownDomainList key={index} onClick={() => onClickDomainOption(domain)}>
+                  <StDropdownDomainList
+                    key={index}
+                    onClick={() => onClickDomainOption(domain)}
+                    isdarkmode={`${isDarkMode}`}
+                  >
                     {domain}
                   </StDropdownDomainList>
                 ))}
@@ -223,10 +229,10 @@ const StDomainSelectBar = styled.div`
   cursor: pointer;
 `;
 
-const StDropdownUnorderedList = styled.ul`
+const StDropdownUnorderedList = styled.ul<{ isdarkmode: string }>`
   position: absolute;
   width: 100%;
-  background-color: white;
+  background-color: ${({ isdarkmode }) => (isdarkmode === 'true' ? '#191a1d' : 'white')};
   margin-top: 5px;
   top: 100%;
   left: 0;
@@ -234,18 +240,19 @@ const StDropdownUnorderedList = styled.ul`
   border-radius: 10px;
 `;
 
-const StDropdownDomainList = styled.li`
+const StDropdownDomainList = styled.li<{ isdarkmode: string }>`
   cursor: pointer;
   padding: 9px 20px;
 
   &:hover {
-    background-color: ${({ theme }) => theme.color.lightGray};
+    background-color: ${({ theme, isdarkmode }) =>
+      isdarkmode === 'true' ? 'black' : theme.color.lightGray};
   }
 
   &:first-child {
     padding-top: 17px;
     padding-bottom: 10px;
-    border-radius: 7px 7px 0 0;
+    border-radius: 10px 10px 0 0;
   }
 
   &:not(:first-child, :last-child) {
@@ -253,7 +260,7 @@ const StDropdownDomainList = styled.li`
   }
 
   &:last-child {
-    border-radius: 0 0 7px 7px;
+    border-radius: 0 0 10px 10px;
     padding-top: 10px;
     padding-bottom: 17px;
   }

--- a/src/components/createPortfolio/EmailForm.tsx
+++ b/src/components/createPortfolio/EmailForm.tsx
@@ -8,6 +8,7 @@ import ErrorMessage from '../common/createPortfolio/ErrorMessage';
 import useOnChangeInput from '@src/Hook/useOnChangeInput';
 import useCloseDropdown from '@src/Hook/useCloseDropdown';
 import useDecodeJWT from '@src/Hook/useDecodeJWT';
+import { StInputLabel } from '@src/style/common/createStepStyles';
 
 interface EmailFormProps {
   isInvalidEmail: boolean;
@@ -163,12 +164,6 @@ const StLabelContainer = styled.div`
   justify-content: space-between;
   padding: 0 2px;
   padding-bottom: 5px;
-`;
-
-const StInputLabel = styled.label`
-  color: gray;
-  font-weight: 800;
-  font-size: 15px;
 `;
 
 const StJoinedEmailCheckWrapper = styled.div`

--- a/src/components/createPortfolio/EmailForm.tsx
+++ b/src/components/createPortfolio/EmailForm.tsx
@@ -9,6 +9,7 @@ import useOnChangeInput from '@src/Hook/useOnChangeInput';
 import useCloseDropdown from '@src/Hook/useCloseDropdown';
 import useDecodeJWT from '@src/Hook/useDecodeJWT';
 import { StInputLabel } from '@src/style/common/createStepStyles';
+import { EMAIL_REGEX } from '../common/createPortfolio/validator';
 
 interface EmailFormProps {
   isInvalidEmail: boolean;
@@ -16,7 +17,7 @@ interface EmailFormProps {
 }
 
 const EmailForm = ({ isInvalidEmail, errorMessage }: EmailFormProps) => {
-  const setEmail = useSetRecoilState(createEmailState);
+  const setEmail = useSetRecoilState<string>(createEmailState);
   const [emailIdValue, setEmailIdValue] = useRecoilState<string>(createEmailIdState);
   const [emailDomainValue, setEmailDomainValue] = useRecoilState<string>(createEmailDomainState);
   const [isDropdownOpen, setIsDropdownOpen] = useState<boolean>(false);
@@ -25,10 +26,11 @@ const EmailForm = ({ isInvalidEmail, errorMessage }: EmailFormProps) => {
 
   const { dropdownRef, onClickOutside } = useCloseDropdown({ isDropdownOpen, setIsDropdownOpen });
 
-  const { onChangeInput: onChangeEmailIdValue } = useOnChangeInput({
-    setRecoilState: setEmailIdValue,
-    setIsCheckboxChecked,
-  });
+  const onChangeEmailIdValue = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const inputValue = e.target.value.replace(EMAIL_REGEX.ID, '');
+    setEmailIdValue(inputValue);
+    setIsCheckboxChecked(false);
+  };
 
   const { onChangeInput: onChangeEmailDomainValue } = useOnChangeInput({
     setRecoilState: setEmailDomainValue,

--- a/src/components/createPortfolio/LocationForm.tsx
+++ b/src/components/createPortfolio/LocationForm.tsx
@@ -1,0 +1,57 @@
+import { createLocationState, createResidenceState } from '@src/states';
+import { PersonalInfoStyle } from '@src/style/common/createStepStyles';
+import { useRecoilState } from 'recoil';
+import SelectDropdown from '../common/createPortfolio/SelectDropdown';
+import { styled } from 'styled-components';
+
+const LocationForm = () => {
+  const [residence, setResidence] = useRecoilState(createResidenceState);
+  const [location, setLocation] = useRecoilState(createLocationState);
+
+  const regionList = [
+    '서울특별시',
+    '부산광역시',
+    '대구광역시',
+    '인천광역시',
+    '광주광역시',
+    '대전광역시',
+    '울산광역시',
+    '세종특별자치시',
+    '경기도',
+    '강원도',
+    '충청도',
+    '전라도',
+    '경상도',
+    '제주특별자치도',
+    '해외',
+  ];
+
+  return (
+    <>
+      <StLocationWrapper>
+        <SelectDropdown
+          dropdownOptions={regionList}
+          selectBarDefaultText="포트폴리오에 표시될 거주지를 선택해주세요."
+          selectedOption={residence}
+          setSelectedOption={setResidence}
+          label="거주지"
+          isPersonalInfo={true}
+        />
+      </StLocationWrapper>
+      <SelectDropdown
+        dropdownOptions={regionList}
+        selectBarDefaultText="포트폴리오에 표시될 희망 근무지역을 선택해주세요."
+        selectedOption={location}
+        setSelectedOption={setLocation}
+        label="희망 근무지역"
+        isPersonalInfo={true}
+      />
+    </>
+  );
+};
+
+const StLocationWrapper = styled.div`
+  z-index: 2;
+`;
+
+export default LocationForm;

--- a/src/components/createPortfolio/PhoneForm.tsx
+++ b/src/components/createPortfolio/PhoneForm.tsx
@@ -1,6 +1,6 @@
 import { ChangeEvent, useEffect, useState } from 'react';
 import { styled } from 'styled-components';
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import { createTelephoneState } from '@src/states';
 import { PersonalInfoStyle } from '@src/style/common/createStepStyles';
 import { ReactComponent as KOR } from '@src/assets/createPortfolio/create-portfolio-phone-kor.svg';
@@ -8,11 +8,13 @@ import { ReactComponent as US } from '@src/assets/createPortfolio/create-portfol
 import { BiCaretDown } from 'react-icons/bi';
 import useCloseDropdown from '@src/Hook/useCloseDropdown';
 import { TELEPHONE_REGEX } from '../common/createPortfolio/validator';
+import { isDarkModeState } from '@src/states/darkModeState';
 
 const PhoneForm = () => {
   const [isDropdownOpen, setIsDropdownOpen] = useState<boolean>(false);
   const [selectedCountryOption, setSelectedCountryOption] = useState<string>('KOR');
   const [telephone, setTelephone] = useRecoilState<string>(createTelephoneState);
+  const isDarkMode = useRecoilValue<boolean>(isDarkModeState);
 
   const { dropdownRef, onClickOutside } = useCloseDropdown({ isDropdownOpen, setIsDropdownOpen });
 
@@ -61,13 +63,17 @@ const PhoneForm = () => {
     <PersonalInfoStyle.Container>
       <PersonalInfoStyle.Label>전화번호</PersonalInfoStyle.Label>
       <StInputWrapper>
-        <StTelephoneSelect onClick={onClickSelectBox}>
+        <StTelephoneSelect onClick={onClickSelectBox} isdarkmode={`${isDarkMode}`}>
           {selectedCountryOption === 'KOR' ? <StKorFlagIcon /> : <StUsFlagIcon />}
           <BiCaretDown />
           {isDropdownOpen && (
-            <StDropdownUnorderedList ref={dropdownRef}>
+            <StDropdownUnorderedList ref={dropdownRef} isdarkmode={`${isDarkMode}`}>
               {dropdownList.map((list, index) => (
-                <StDropdownList key={index} onClick={() => onClickOption(list.value)}>
+                <StDropdownList
+                  key={index}
+                  onClick={() => onClickOption(list.value)}
+                  isdarkmode={`${isDarkMode}`}
+                >
                   <span>{list.value}</span>
                   <span className="number">{list.number}</span>
                 </StDropdownList>
@@ -104,9 +110,10 @@ const StInputWrapper = styled.div`
   font-weight: 600;
 `;
 
-const StTelephoneSelect = styled.div`
+const StTelephoneSelect = styled.div<{ isdarkmode: string }>`
   width: 70px;
-  background-color: ${({ theme }) => theme.color.gray};
+  background-color: ${({ theme, isdarkmode }) =>
+    isdarkmode === 'true' ? theme.color.fontColor : theme.color.gray};
   padding: 5px;
   border-radius: 5px;
   margin-right: 3px;
@@ -118,7 +125,7 @@ const StTelephoneSelect = styled.div`
   cursor: pointer;
 `;
 
-const StDropdownUnorderedList = styled.ul`
+const StDropdownUnorderedList = styled.ul<{ isdarkmode: string }>`
   position: absolute;
   display: flex;
   flex-direction: column;
@@ -127,11 +134,12 @@ const StDropdownUnorderedList = styled.ul`
   margin-top: 3px;
   top: 100%;
   left: 0;
-  background-color: white;
+  background-color: ${({ theme, isdarkmode }) =>
+    isdarkmode === 'true' ? theme.color.darkModeGray : 'white'};
   border: 1px solid ${({ theme }) => theme.color.paleGray};
 `;
 
-const StDropdownList = styled.li`
+const StDropdownList = styled.li<{ isdarkmode: string }>`
   padding: 10px 7px;
   display: flex;
   justify-content: space-between;
@@ -144,14 +152,17 @@ const StDropdownList = styled.li`
 
   &:first-child {
     padding-top: 15px;
+    border-radius: 5px 5px 0 0;
   }
 
   &:last-child {
     padding-bottom: 15px;
+    border-radius: 0 0 5px 5px;
   }
 
   &:hover {
-    background-color: ${({ theme }) => theme.color.lightGray};
+    background-color: ${({ theme, isdarkmode }) =>
+      isdarkmode === 'true' ? 'black' : theme.color.lightGray};
   }
 `;
 

--- a/src/components/createPortfolio/PhoneForm.tsx
+++ b/src/components/createPortfolio/PhoneForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { ChangeEvent, useEffect, useState } from 'react';
 import { styled } from 'styled-components';
 import { useRecoilState } from 'recoil';
 import { createTelephoneState } from '@src/states';
@@ -6,15 +6,14 @@ import { PersonalInfoStyle } from '@src/style/common/createStepStyles';
 import { ReactComponent as KOR } from '@src/assets/createPortfolio/create-portfolio-phone-kor.svg';
 import { ReactComponent as US } from '@src/assets/createPortfolio/create-portfolio-phone-us.svg';
 import { BiCaretDown } from 'react-icons/bi';
-import useOnChangeInput from '@src/Hook/useOnChangeInput';
 import useCloseDropdown from '@src/Hook/useCloseDropdown';
+import { TELEPHONE_REGEX } from '../common/createPortfolio/validator';
 
 const PhoneForm = () => {
   const [isDropdownOpen, setIsDropdownOpen] = useState<boolean>(false);
   const [selectedCountryOption, setSelectedCountryOption] = useState<string>('KOR');
   const [telephone, setTelephone] = useRecoilState<string>(createTelephoneState);
 
-  const { onChangeInput: onChangeTelephone } = useOnChangeInput({ setRecoilState: setTelephone });
   const { dropdownRef, onClickOutside } = useCloseDropdown({ isDropdownOpen, setIsDropdownOpen });
 
   const dropdownList = [
@@ -29,6 +28,25 @@ const PhoneForm = () => {
   const onClickOption = (option: string) => {
     setSelectedCountryOption(option);
     setIsDropdownOpen(false);
+  };
+
+  const onChangeKorHypenTelephone = (e: ChangeEvent<HTMLInputElement>) => {
+    let hypenValue = e.target.value.replace(TELEPHONE_REGEX.ONLY_NUMBER, '');
+    if (e.target.value.length < 11) {
+      hypenValue = hypenValue.replace(TELEPHONE_REGEX.KOR_FIRST_TWO_NUMBER, `$1-$2-$3`);
+    } else {
+      hypenValue = hypenValue.replace(TELEPHONE_REGEX.KOR_FIRST_THREE_NUMBER, `$1-$2-$3`);
+    }
+
+    setTelephone(hypenValue);
+  };
+
+  const onChangeUsHypenTelephone = (e: ChangeEvent<HTMLInputElement>) => {
+    let hypenValue = e.target.value
+      .replace(TELEPHONE_REGEX.ONLY_NUMBER, '')
+      .replace(TELEPHONE_REGEX.US_NUMBER, `$1-$2-$3`);
+
+    setTelephone(hypenValue);
   };
 
   useEffect(() => {
@@ -57,12 +75,23 @@ const PhoneForm = () => {
             </StDropdownUnorderedList>
           )}
         </StTelephoneSelect>
-        <PersonalInfoStyle.Input
-          type="tel"
-          value={telephone}
-          onChange={onChangeTelephone}
-          placeholder="포트폴리오에 표시될 전화번호를 입력해주세요."
-        />
+        {selectedCountryOption === 'KOR' ? (
+          <PersonalInfoStyle.Input
+            type="tel"
+            value={telephone}
+            onChange={onChangeKorHypenTelephone}
+            maxLength={13}
+            placeholder="포트폴리오에 표시될 전화번호를 입력해주세요."
+          />
+        ) : (
+          <PersonalInfoStyle.Input
+            type="tel"
+            value={telephone}
+            maxLength={10}
+            onChange={onChangeUsHypenTelephone}
+            placeholder="포트폴리오에 표시될 전화번호를 입력해주세요."
+          />
+        )}
       </StInputWrapper>
     </PersonalInfoStyle.Container>
   );
@@ -93,7 +122,7 @@ const StDropdownUnorderedList = styled.ul`
   position: absolute;
   display: flex;
   flex-direction: column;
-  width: 80px;
+  width: 100px;
   border-radius: 5px;
   margin-top: 3px;
   top: 100%;
@@ -103,7 +132,7 @@ const StDropdownUnorderedList = styled.ul`
 `;
 
 const StDropdownList = styled.li`
-  padding: 3px 5px;
+  padding: 10px 7px;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -114,11 +143,11 @@ const StDropdownList = styled.li`
   }
 
   &:first-child {
-    padding-top: 5px;
+    padding-top: 15px;
   }
 
   &:last-child {
-    padding-bottom: 5px;
+    padding-bottom: 15px;
   }
 
   &:hover {

--- a/src/components/createPortfolio/PortfolioFilter.tsx
+++ b/src/components/createPortfolio/PortfolioFilter.tsx
@@ -3,6 +3,8 @@ import { useEffect, useState } from 'react';
 import { styled } from 'styled-components';
 import SelectCategoryRequest from './SelectCategoryRequest';
 import { StInputLabel } from '../../style/common/createStepStyles';
+import { useRecoilValue } from 'recoil';
+import { isDarkModeState } from '@src/states/darkModeState';
 
 interface PortfolioFilterProps {
   category: string;
@@ -12,7 +14,8 @@ interface PortfolioFilterProps {
 
 const PortfolioFilter = ({ category, selectedFilter, setSelectedFilter }: PortfolioFilterProps) => {
   const [filterList, setFilterList] = useState<string[]>([]);
-  const [isSelectCategory, setIsSelectCategory] = useState(false);
+  const [isSelectCategory, setIsSelectCategory] = useState<boolean>(false);
+  const isDarkMode = useRecoilValue<boolean>(isDarkModeState);
 
   const onClickFilterItem = (selectFilter: string) => {
     setSelectedFilter(selectFilter);
@@ -49,6 +52,7 @@ const PortfolioFilter = ({ category, selectedFilter, setSelectedFilter }: Portfo
               type="button"
               onClick={() => onClickFilterItem(filter)}
               isselected={`${selectedFilter === filter}`}
+              isdarkmode={`${isDarkMode}`}
             >
               {filter}
             </StFilterButton>
@@ -80,14 +84,16 @@ const StFilterListContainer = styled.div`
   }
 `;
 
-const StFilterButton = styled.button<{ isselected: string }>`
+const StFilterButton = styled.button<{ isselected: string; isdarkmode: string }>`
   border-radius: 50px;
   padding: 10px 20px;
   outline: ${({ isselected, theme: { color } }) =>
-    isselected === 'true' ? `1px solid ${color.neonGreen}` : 'none'};
+    isselected === 'true' ? `1px solid ${color.neonGreen}` : '1px solid white'};
   font-weight: ${({ isselected }) => (isselected === 'true' ? `900` : '600')};
   background-color: ${({ isselected, theme: { color } }) =>
     isselected === 'true' ? color.neonGreen : 'none'};
+  color: ${({ isdarkmode, isselected }) =>
+    isdarkmode === 'true' && (isselected === 'true' ? 'black' : 'white')};
 `;
 
 export default PortfolioFilter;

--- a/src/components/createPortfolio/TechStackTag.tsx
+++ b/src/components/createPortfolio/TechStackTag.tsx
@@ -113,6 +113,7 @@ const StTechStackTagList = styled.li`
 const StTechStackTagText = styled.span`
   font-weight: 700;
   padding: 10px 35px;
+  color: black;
 `;
 
 const StTagDeleteIconWrapper = styled.div`

--- a/src/components/createPortfolio/createStep/Step01Intro.tsx
+++ b/src/components/createPortfolio/createStep/Step01Intro.tsx
@@ -1,14 +1,19 @@
 import { styled } from 'styled-components';
 import { STEP } from '@src/constants/createPortfolioConstants';
 import { ReactComponent as Logo } from '@src/assets/logo.svg';
+import { ReactComponent as DarkModeLogo } from '@src/assets/dark-mode-logo.svg';
 import { ReactComponent as LabelNumberOne } from '@src/assets/createPortfolio/create-portfolio-step01-intro-number-1.svg';
 import { ReactComponent as LabelNumberTwo } from '@src/assets/createPortfolio/create-portfolio-step01-intro-number-2.svg';
 import { ReactComponent as LabelNumberThree } from '@src/assets/createPortfolio/create-portfolio-step01-intro-number-3.svg';
 import NextStepButton from '@src/components/common/createPortfolio/NextStepButton';
+import { useRecoilValue } from 'recoil';
+import { isDarkModeState } from '@src/states/darkModeState';
 
 const Step01Intro: React.FC<{ onNextButtonClick: (step: string) => void }> = ({
   onNextButtonClick,
 }) => {
+  const isDarkMode = useRecoilValue<boolean>(isDarkModeState);
+
   const descriptionDetail = [
     {
       id: 1,
@@ -35,7 +40,7 @@ const Step01Intro: React.FC<{ onNextButtonClick: (step: string) => void }> = ({
       <StContentContainer>
         <StDescriptionContainer>
           <StLogoAndTextDescriptionContainer>
-            <StLogo />
+            <StLogoWrapper>{isDarkMode ? <DarkModeLogo /> : <Logo />}</StLogoWrapper>
             <StDescriptionText>과 함께</StDescriptionText>
           </StLogoAndTextDescriptionContainer>
           <StDescriptionText>포트폴리오를 입력해볼까요?</StDescriptionText>
@@ -116,39 +121,41 @@ const StLogoAndTextDescriptionContainer = styled.div`
   }
 `;
 
-const StLogo = styled(Logo)`
-  width: 82px;
-  height: 30px;
-
-  @media screen and (max-width: 1350px) {
-    transition: 0.5s;
-    width: 80px;
-    height: 28px;
-  }
-  @media screen and (max-width: 1205px) {
-    transition: 0.5s;
-    width: 77px;
-    height: 25px;
-  }
-  @media ${({ theme }) => theme.size.tablet} {
-    transition: 0.5s;
+const StLogoWrapper = styled.div`
+  & svg {
     width: 82px;
     height: 30px;
-  }
-  @media screen and (max-width: 580px) {
-    transition: 0.5s;
-    width: 77px;
-    height: 25px;
-  }
-  @media screen and (max-width: 520px) {
-    transition: 0.5s;
-    width: 68px;
-    height: 23px;
-  }
-  @media ${({ theme }) => theme.size.mobileColumn} {
-    transition: 0.5s;
-    width: 64px;
-    height: 19px;
+
+    @media screen and (max-width: 1350px) {
+      transition: 0.5s;
+      width: 80px;
+      height: 28px;
+    }
+    @media screen and (max-width: 1205px) {
+      transition: 0.5s;
+      width: 77px;
+      height: 25px;
+    }
+    @media ${({ theme }) => theme.size.tablet} {
+      transition: 0.5s;
+      width: 82px;
+      height: 30px;
+    }
+    @media screen and (max-width: 580px) {
+      transition: 0.5s;
+      width: 77px;
+      height: 25px;
+    }
+    @media screen and (max-width: 520px) {
+      transition: 0.5s;
+      width: 68px;
+      height: 23px;
+    }
+    @media ${({ theme }) => theme.size.mobileColumn} {
+      transition: 0.5s;
+      width: 64px;
+      height: 19px;
+    }
   }
 `;
 

--- a/src/components/createPortfolio/createStep/Step02CategoryFilter.tsx
+++ b/src/components/createPortfolio/createStep/Step02CategoryFilter.tsx
@@ -19,8 +19,8 @@ const Step02CategoryFilter = ({
   onNextButtonClick,
   onPrevButtonClick,
 }: CreatePortfolioStepProps) => {
-  const [category, setCategory] = useRecoilState(createCategoryState);
-  const [filter, setFilter] = useRecoilState(createFilterState);
+  const [category, setCategory] = useRecoilState<string>(createCategoryState);
+  const [filter, setFilter] = useRecoilState<string>(createFilterState);
 
   const { isSnackbarVisible, showSnackbarPopup } = useSnackbarPopup();
 

--- a/src/components/createPortfolio/createStep/Step03Title.tsx
+++ b/src/components/createPortfolio/createStep/Step03Title.tsx
@@ -16,7 +16,7 @@ import useSnackbarPopup from '@src/Hook/useSnackbarPopup';
 import SnackbarPopup from '@src/components/common/SnackbarPopup';
 
 const Step03Title = ({ onNextButtonClick, onPrevButtonClick }: CreatePortfolioStepProps) => {
-  const [portfolioTitle, setPortfolioTitle] = useRecoilState(createTitleState);
+  const [portfolioTitle, setPortfolioTitle] = useRecoilState<string>(createTitleState);
 
   const {
     onChangeInput,

--- a/src/components/createPortfolio/createStep/Step04PersonalInfo.tsx
+++ b/src/components/createPortfolio/createStep/Step04PersonalInfo.tsx
@@ -11,13 +11,11 @@ import useOnChangeInput from '@src/Hook/useOnChangeInput';
 import NextStepButton from '@src/components/common/createPortfolio/NextStepButton';
 import PrevStepButton from '@src/components/common/createPortfolio/PrevStepButton';
 import TitleTextLabel from '@src/components/common/createPortfolio/TitleTextLabel';
-import AdditionalPersonalInfo from '../AdditionalPersonalInfo';
-import ErrorMessage from '../../common/createPortfolio/ErrorMessage';
 import useSnackbarPopup from '@src/Hook/useSnackbarPopup';
 import SnackbarPopup from '@src/components/common/SnackbarPopup';
 import EmailForm from '../EmailForm';
-import { useState } from 'react';
 import PhoneForm from '../PhoneForm';
+import LocationForm from '../LocationForm';
 
 const Step04PersonalInfo = ({ onNextButtonClick, onPrevButtonClick }: CreatePortfolioStepProps) => {
   const [email, setEmail] = useRecoilState<string>(createEmailState);
@@ -46,9 +44,21 @@ const Step04PersonalInfo = ({ onNextButtonClick, onPrevButtonClick }: CreatePort
       <S.ContentContainer>
         <TitleTextLabel title={title} description={description} />
         <StPersonalInfoForm>
-          <EmailForm isInvalidEmail={isInvalidEmail} errorMessage={errorMessage} />
-          <PhoneForm />
-          <AdditionalPersonalInfo sharedStyle={sharedStyle} />
+          <StEmailFormWrapper>
+            <StFormDescriptionText>
+              <span className="asteriskMark">*</span>필수 입력
+            </StFormDescriptionText>
+            <EmailForm isInvalidEmail={isInvalidEmail} errorMessage={errorMessage} />
+          </StEmailFormWrapper>
+          <StAdditionalInfoContainer>
+            <StFormDescriptionText>선택 입력</StFormDescriptionText>
+            <StAdditionalInfoWrapper>
+              <StPhoneFormWrapper>
+                <PhoneForm />
+              </StPhoneFormWrapper>
+              <LocationForm />
+            </StAdditionalInfoWrapper>
+          </StAdditionalInfoContainer>
         </StPersonalInfoForm>
       </S.ContentContainer>
 
@@ -77,14 +87,38 @@ const StPersonalInfoForm = styled.div`
   }
 `;
 
-const sharedStyle = `
-  width: 100%;
-  height: 65px;
+const StFormDescriptionText = styled.span`
+  color: ${({ theme }) => theme.color.lightGreen};
+  font-weight: 550;
+
+  .asteriskMark {
+    color: ${({ theme }) => theme.color.lightGreen};
+    font-size: 18px;
+    font-weight: 800;
+  }
+`;
+
+const StEmailFormWrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 5px;
+  z-index: 3;
+`;
 
-  padding: 10px;
+const StPhoneFormWrapper = styled.div`
+  z-index: 2;
+`;
+
+const StAdditionalInfoContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+`;
+
+const StAdditionalInfoWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 `;
 
 export default Step04PersonalInfo;

--- a/src/components/createPortfolio/createStep/Step04PersonalInfo.tsx
+++ b/src/components/createPortfolio/createStep/Step04PersonalInfo.tsx
@@ -102,11 +102,11 @@ const StEmailFormWrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 5px;
-  z-index: 3;
+  z-index: 4;
 `;
 
 const StPhoneFormWrapper = styled.div`
-  z-index: 2;
+  z-index: 3;
 `;
 
 const StAdditionalInfoContainer = styled.div`

--- a/src/components/createPortfolio/createStep/Step08Link.tsx
+++ b/src/components/createPortfolio/createStep/Step08Link.tsx
@@ -13,55 +13,65 @@ import {
 import { CreatePortfolioStepProps } from '@src/types/portfolioType';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import { styled } from 'styled-components';
+import { GITHUB_ID_REGEX, LINK_REGEX } from '@src/components/common/createPortfolio/validator';
 
 const Step08Link = ({ onNextButtonClick, onPrevButtonClick }: CreatePortfolioStepProps) => {
   const [youtubeUrl, setYoutubeUrl] = useRecoilState<string>(createYoutubeState);
   const [blogUrl, setBlogUrl] = useRecoilState<string>(createBlogState);
   const [githubID, setGithubID] = useRecoilState<string>(createGithubState);
 
-  const { onChangeInput: onChangeYoutubeUrl } = useOnChangeInput({ setRecoilState: setYoutubeUrl });
-  const { onChangeInput: onChangeBlogUrl } = useOnChangeInput({ setRecoilState: setBlogUrl });
-  const { onChangeInput: onChangeGithubID } = useOnChangeInput({ setRecoilState: setGithubID });
+  const { onChangeInput: onChangeYoutubeUrl } = useOnChangeInput({
+    setRecoilState: setYoutubeUrl,
+    REGEX: LINK_REGEX,
+  });
+  const { onChangeInput: onChangeBlogUrl } = useOnChangeInput({
+    setRecoilState: setBlogUrl,
+    REGEX: LINK_REGEX,
+  });
+  const { onChangeInput: onChangeGithubID } = useOnChangeInput({
+    setRecoilState: setGithubID,
+    REGEX: GITHUB_ID_REGEX,
+  });
 
   const selectedCategory = useRecoilValue(createCategoryState);
   const isDeveloper = selectedCategory === 'Develop';
 
   const title = '포트폴리오에 표시될 추가정보를 알려주세요';
   const description =
-    '입력하신 경우에만 링크 미리보기가 포트폴리오에 표시되고,\n입력하지 않아도 포트폴리오가 정상적으로 작성됩니다.';
+    '영문으로만 입력이 가능하니 한/영 키를 확인해주세요!\n추가정보를 입력하신 경우에만 링크 미리보기가 포트폴리오에 표시되고,\n입력하지 않아도 포트폴리오가 정상적으로 작성됩니다.';
 
   return (
     <S.Container>
       <S.ContentContainer>
         <TitleTextLabel title={title} description={description} />
-        <StOutLineDiv isgithubexist={`${isDeveloper}`}>
-          <StUrlItem>
-            <StLabel>Youtube</StLabel>
-            <StInput
+        <StInputContainer>
+          <S.PersonalInfoStyle.Container>
+            <S.PersonalInfoStyle.Label>Youtube</S.PersonalInfoStyle.Label>
+            <S.PersonalInfoStyle.Input
               value={youtubeUrl}
               onChange={onChangeYoutubeUrl}
               placeholder="Youtube 활동을 하고 계시다면 관련 링크를 입력해주세요."
             />
-          </StUrlItem>
-          <StUrlItem>
-            <StLabel>Blog</StLabel>
-            <StInput
+          </S.PersonalInfoStyle.Container>
+          <S.PersonalInfoStyle.Container>
+            <S.PersonalInfoStyle.Label>Blog</S.PersonalInfoStyle.Label>
+            <S.PersonalInfoStyle.Input
               value={blogUrl}
               onChange={onChangeBlogUrl}
-              placeholder="작성 중인 blog가 있다면 관련 링크를 입력해주세요."
+              placeholder="운영하는 blog가 있다면 관련 링크를 입력해주세요."
             />
-          </StUrlItem>
+          </S.PersonalInfoStyle.Container>
           {isDeveloper && (
-            <StUrlItem>
-              <StLabel>Github ID</StLabel>
-              <StInput
+            <S.PersonalInfoStyle.Container>
+              <S.PersonalInfoStyle.Label>Github ID</S.PersonalInfoStyle.Label>
+              <S.PersonalInfoStyle.Input
                 value={githubID}
                 onChange={onChangeGithubID}
                 placeholder="작성하신 Github ID의 commit contributions이 포트폴리오에 표시됩니다."
               />
-            </StUrlItem>
+            </S.PersonalInfoStyle.Container>
           )}
-        </StOutLineDiv>
+        </StInputContainer>
       </S.ContentContainer>
       <S.ButtonContainer>
         <PrevStepButton onClick={() => onPrevButtonClick(STEP.SEVEN)} />
@@ -71,48 +81,14 @@ const Step08Link = ({ onNextButtonClick, onPrevButtonClick }: CreatePortfolioSte
   );
 };
 
-const StOutLineDiv = styled.div<{ isgithubexist: string }>`
+const StInputContainer = styled.div`
   width: 750px;
-  height: ${({ isgithubexist }) => (isgithubexist === 'true' ? '195px' : '130px')};
-  border: 1px solid gray;
-  border-radius: 10px;
-
-  @media ${({ theme }) => theme.size.tablet} {
-    width: 100%;
-  }
-`;
-
-const StUrlItem = styled.div`
-  width: 750px;
-  height: 65px;
   display: flex;
   flex-direction: column;
-  gap: 5px;
-
-  padding: 10px;
-
-  border-bottom: 1px solid gray;
-
-  &:last-child {
-    border: none;
-  }
+  gap: 10px;
 
   @media ${({ theme }) => theme.size.tablet} {
     width: 100%;
-  }
-`;
-
-const StLabel = styled.div`
-  color: gray;
-  font-size: 15px;
-`;
-
-const StInput = styled.input`
-  height: 100%;
-  border: none;
-
-  &::placeholder {
-    color: #b5b5b5;
   }
 `;
 

--- a/src/components/main/Filter.tsx
+++ b/src/components/main/Filter.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { styled } from 'styled-components';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import { filterState, selectedCategoryState } from '@src/states';
+import { isDarkModeState } from '@src/states/darkModeState';
 import { CATEGORY_KEYWORD } from '@src/constants/portfolioFilteringData';
 import theme from '@src/style/theme';
 
@@ -12,8 +13,9 @@ interface FilterPropsType {
 
 const Filter = ({ filterList, onClickFilterButton }: FilterPropsType) => {
   const [filter, setFilter] = useRecoilState<string>(filterState);
-  const [backgroundColor, setBackgroundColor] = useState('');
-  const selectedCategory = useRecoilValue(selectedCategoryState);
+  const [backgroundColor, setBackgroundColor] = useState<string>('');
+  const selectedCategory = useRecoilValue<string>(selectedCategoryState);
+  const isDarkMode = useRecoilValue<boolean>(isDarkModeState);
 
   const onClickFilter = (filterKeyword: string) => {
     setFilter(filterKeyword);
@@ -44,6 +46,7 @@ const Filter = ({ filterList, onClickFilterButton }: FilterPropsType) => {
           onClick={() => onClickFilter(filterKeyword)}
           isselected={`${filterKeyword === filter}`}
           color={backgroundColor}
+          isdarkmode={`${isDarkMode}`}
         >
           {filterKeyword}
         </StFilterButton>
@@ -72,14 +75,16 @@ const StFilterListContainer = styled.div`
   }
 `;
 
-const StFilterButton = styled.button<{ isselected: string; color: string }>`
+const StFilterButton = styled.button<{ isselected: string; color: string; isdarkmode: string }>`
   font-size: 16px;
   width: 140px;
   height: 37px;
   border-radius: 50px;
-  background-color: ${({ theme, isselected, color }) =>
-    isselected === 'true' ? color : theme.color.lightGray};
+  background-color: ${({ theme, isselected, color, isdarkmode }) =>
+    isselected === 'true' ? color : isdarkmode === 'true' ? '#4B4B4B' : theme.color.lightGray};
   font-weight: ${({ isselected }) => isselected === 'true' && '800'};
+  color: ${({ isdarkmode, isselected }) =>
+    isdarkmode === 'true' ? (isselected === 'true' ? 'black' : 'white') : 'black'};
 
   @media ${({ theme }) => theme.size.mobileRow} {
     font-size: 13px;

--- a/src/components/myPortfolio/NoPortfolio.tsx
+++ b/src/components/myPortfolio/NoPortfolio.tsx
@@ -17,8 +17,7 @@ const NoPortfolio = () => {
 
   return (
     <StNoPortfolio>
-      <NotFoundDarkModeIcon />
-      {/* {isDarkMode ? <NotFoundDarkModeIcon /> : <NotFoundIcon />} */}
+      {isDarkMode ? <NotFoundDarkModeIcon /> : <NotFoundIcon />}
       <StNoPortfolioText>
         작성하신 포트폴리오가 없습니다.
         <br />

--- a/src/components/myPortfolio/myPortfolioItem.tsx
+++ b/src/components/myPortfolio/myPortfolioItem.tsx
@@ -66,6 +66,7 @@ const StImgWrapper = styled.div`
 
 const StDeleteIcon = styled(CgClose)`
   font-size: 18px;
+  color: black;
 `;
 
 const StIconWrapper = styled.div`

--- a/src/components/nav/Auth.tsx
+++ b/src/components/nav/Auth.tsx
@@ -1,16 +1,17 @@
 import { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import { loginState } from '@src/states';
 import { ReactComponent as AuthIcon } from '@src/assets/nav/nav-logout-icon.svg';
 import useResetCreatePortfolioRecoilValues from '@src/Hook/useResetCreatePortfolioRecoilValues';
 import useResetSelectedFilterRecoilValues from '@src/Hook/useResetSelectedFilterRecoilValues';
 import { DesktopAndTablet } from '@src/style/mediaQuery';
 import { NavProps } from '@src/shared/Nav';
+import { isDarkModeState } from '@src/states/darkModeState';
 
 const Auth = ({ setIsLoginModalOpen, setIsLogoutModalOpen }: NavProps) => {
-  const [isLogin, setIsLogin] = useRecoilState(loginState);
+  const [isLogin, setIsLogin] = useRecoilState<boolean>(loginState);
+  const isDarkMode = useRecoilValue<boolean>(isDarkModeState);
   const resetRecoilValues = useResetCreatePortfolioRecoilValues();
   const resetSelectedRecoilValue = useResetSelectedFilterRecoilValues();
 
@@ -34,7 +35,7 @@ const Auth = ({ setIsLoginModalOpen, setIsLogoutModalOpen }: NavProps) => {
   return (
     <StAuth>
       <StAuthClickContainer onClick={onClickAuth}>
-        <AuthIcon />
+        <StAuthIcon isdarkmode={`${isDarkMode}`} />
         <DesktopAndTablet>
           <StLabel>{isLogin ? 'Logout' : 'Login'}</StLabel>
         </DesktopAndTablet>
@@ -44,14 +45,23 @@ const Auth = ({ setIsLoginModalOpen, setIsLogoutModalOpen }: NavProps) => {
 };
 
 const StAuth = styled.div`
-  margin-bottom: 50px;
+  margin-bottom: 20px;
+  @media ${({ theme }) => theme.size.mobileRow} {
+    display: flex;
+    justify-content: center;
+  }
 `;
 
 const StAuthClickContainer = styled.span`
   display: flex;
   align-items: center;
-  display: inline-flex;
   cursor: pointer;
+`;
+
+const StAuthIcon = styled(AuthIcon)<{ isdarkmode: string }>`
+  & path {
+    stroke: ${({ isdarkmode }) => isdarkmode === 'true' && 'white'};
+  }
 `;
 
 const StLabel = styled.span`

--- a/src/components/nav/Category.tsx
+++ b/src/components/nav/Category.tsx
@@ -1,5 +1,5 @@
 import { css, styled } from 'styled-components';
-import { useRecoilState, useSetRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import { useNavigate } from 'react-router-dom';
 import {
   categoryState,
@@ -12,12 +12,14 @@ import {
   categoryListForDisplay,
 } from '@src/constants/portfolioFilteringData';
 import { PATH_URL } from '@src/constants/constants';
+import { isDarkModeState } from '@src/states/darkModeState';
 
 const Category = () => {
   const setCategory = useSetRecoilState<string>(categoryState);
   const setFilter = useSetRecoilState<string>(filterState);
-  const [selectedCategory, setSelectedCategory] = useRecoilState(selectedCategoryState);
-  const setSelectedHeader = useSetRecoilState(selectedHeaderState);
+  const [selectedCategory, setSelectedCategory] = useRecoilState<string>(selectedCategoryState);
+  const setSelectedHeader = useSetRecoilState<boolean>(selectedHeaderState);
+  const isDarkMode = useRecoilValue<boolean>(isDarkModeState);
 
   const navigate = useNavigate();
 
@@ -37,7 +39,11 @@ const Category = () => {
     <StCategory>
       {categoryListForDisplay.map((categoryItem, categoryItemIndex: number) => (
         <StCategoryItem key={categoryItemIndex} onClick={() => onClickCategory(categoryItem.value)}>
-          {categoryItem.icon && <categoryItem.icon />}
+          {categoryItem.icon && (
+            <StIconWrapper isdarkmode={`${isDarkMode}`}>
+              <categoryItem.icon />
+            </StIconWrapper>
+          )}
           <StLabel
             key={categoryItemIndex}
             isclicked={`${selectedCategory === categoryItem.value}`}
@@ -62,6 +68,14 @@ const StCategoryItem = styled.div`
   display: flex;
   align-items: center;
   cursor: pointer;
+`;
+
+const StIconWrapper = styled.div<{ isdarkmode: string }>`
+  & svg {
+    & path {
+      fill: ${({ isdarkmode }) => isdarkmode === 'true' && '#B4B4B4'};
+    }
+  }
 `;
 
 const StLabel = styled.div<{ isclicked: string; color: string; value: string }>`

--- a/src/components/nav/NavContent.tsx
+++ b/src/components/nav/NavContent.tsx
@@ -23,7 +23,6 @@ const NavContent = ({ setIsLoginModalOpen, setIsLogoutModalOpen }: NavProps) => 
           setIsLoginModalOpen={setIsLoginModalOpen}
           setIsLogoutModalOpen={setIsLogoutModalOpen}
         />
-        {/* TODO: 다크모드 2차 scope */}
         <LightAndDarkMode />
       </StBottomContainer>
     </>
@@ -41,7 +40,6 @@ const StCategoryContainer = styled.div`
 const StBottomContainer = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 15px;
 `;
 
 export default NavContent;

--- a/src/components/project/ProjectItem.tsx
+++ b/src/components/project/ProjectItem.tsx
@@ -3,9 +3,11 @@ import { useState, useEffect } from 'react';
 import { IoMdCloseCircle } from 'react-icons/io';
 import { ProjectDataType } from '@src/types/portfolioType';
 import { getUser } from '@src/apis/user';
+import { ReactComponent as DeleteModalIcon } from '@src/assets/delete-post-modal-icon.svg';
 import useDecodeJWT from '@src/Hook/useDecodeJWT';
 import UserProfileImage from '../common/UserProfileImage';
 import NoImage from '../common/NoImage';
+import Modal from '../common/Modal';
 
 interface ProjectItemProps {
   project: ProjectDataType;
@@ -15,10 +17,19 @@ interface ProjectItemProps {
 
 const ProjectItem = ({ project, isEditMode, deleteProject }: ProjectItemProps) => {
   const [userData, setUserData] = useState({ nickname: '', profileImage: null });
-  const [imageLoadError, setImageLoadError] = useState(false);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState<boolean>(false);
+  const [imageLoadError, setImageLoadError] = useState<boolean>(false);
 
   const onImageError = () => {
     setImageLoadError(true);
+  };
+
+  const openDeleteModal = () => {
+    setIsDeleteModalOpen(true);
+  };
+
+  const onCloseDeleteModal = () => {
+    setIsDeleteModalOpen(false);
   };
 
   useEffect(() => {
@@ -35,7 +46,7 @@ const ProjectItem = ({ project, isEditMode, deleteProject }: ProjectItemProps) =
     <StProjectItem>
       <StImgContainer>
         {isEditMode && (
-          <StIconContainer onClick={() => deleteProject && deleteProject(project.id)}>
+          <StIconContainer onClick={openDeleteModal}>
             <StDeleteIcon />
           </StIconContainer>
         )}
@@ -61,6 +72,19 @@ const ProjectItem = ({ project, isEditMode, deleteProject }: ProjectItemProps) =
           <StUserName>{userData.nickname}</StUserName>
         </StBottomDescription>
       </StDescriptionContainer>
+      {isDeleteModalOpen && (
+        <Modal
+          Icon={DeleteModalIcon}
+          onClose={onCloseDeleteModal}
+          deletePost={deleteProject}
+          mainText="프로젝트를 정말 삭제할까요?"
+          subText="삭제하고 나면 복구할 수 없어요."
+          mainButtonText="취소"
+          subButtonText="삭제하기"
+          selectedId={project.id}
+          type="multiline"
+        />
+      )}
     </StProjectItem>
   );
 };

--- a/src/components/project/ProjectItem.tsx
+++ b/src/components/project/ProjectItem.tsx
@@ -8,6 +8,8 @@ import useDecodeJWT from '@src/Hook/useDecodeJWT';
 import UserProfileImage from '../common/UserProfileImage';
 import NoImage from '../common/NoImage';
 import Modal from '../common/Modal';
+import { useRecoilValue } from 'recoil';
+import { isDarkModeState } from '@src/states/darkModeState';
 
 interface ProjectItemProps {
   project: ProjectDataType;
@@ -19,6 +21,7 @@ const ProjectItem = ({ project, isEditMode, deleteProject }: ProjectItemProps) =
   const [userData, setUserData] = useState({ nickname: '', profileImage: null });
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState<boolean>(false);
   const [imageLoadError, setImageLoadError] = useState<boolean>(false);
+  const isDarkMode = useRecoilValue<boolean>(isDarkModeState);
 
   const onImageError = () => {
     setImageLoadError(true);
@@ -64,12 +67,12 @@ const ProjectItem = ({ project, isEditMode, deleteProject }: ProjectItemProps) =
       </StImgContainer>
       <StDescriptionContainer>
         <StTopDescription>
-          <StProjectTitle>{project.title}</StProjectTitle>
+          <StProjectTitle isdarkmode={`${isDarkMode}`}>{project.title}</StProjectTitle>
           <StProjectPosition>{project.position}</StProjectPosition>
         </StTopDescription>
         <StBottomDescription>
           <UserProfileImage imgSrc={userData.profileImage} size="25px" />
-          <StUserName>{userData.nickname}</StUserName>
+          <StUserName isdarkmode={`${isDarkMode}`}>{userData.nickname}</StUserName>
         </StBottomDescription>
       </StDescriptionContainer>
       {isDeleteModalOpen && (
@@ -141,10 +144,10 @@ const StTopDescription = styled.div`
   align-items: center;
 `;
 
-const StProjectTitle = styled.div`
+const StProjectTitle = styled.div<{ isdarkmode: string }>`
   font-weight: bold;
   font-size: 19px;
-  color: ${({ theme }) => theme.color.fontColor};
+  color: ${({ theme, isdarkmode }) => (isdarkmode === 'true' ? 'white' : theme.color.fontColor)};
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
@@ -163,10 +166,10 @@ const StBottomDescription = styled.div`
   align-items: center;
 `;
 
-const StUserName = styled.div`
+const StUserName = styled.div<{ isdarkmode: string }>`
   margin-left: 10px;
   font-weight: bold;
-  color: ${({ theme }) => theme.color.fontColor};
+  color: ${({ theme, isdarkmode }) => (isdarkmode === 'true' ? 'white' : theme.color.fontColor)};
 `;
 
 export default ProjectItem;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -28,7 +28,7 @@ const Home = () => {
   const setFilter = useSetRecoilState<string>(filterState);
   const setSelectedCategory = useSetRecoilState<string>(selectedCategoryState);
   const setSelectedHeader = useSetRecoilState<boolean>(selectedHeaderState);
-  const isDarkMode = useRecoilValue(isDarkModeState);
+  const isDarkMode = useRecoilValue<boolean>(isDarkModeState);
 
   const navigate = useNavigate();
 

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -2,13 +2,17 @@ import { useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { styled } from 'styled-components';
 import { ReactComponent as ErrorIcon } from '@src/assets/not-found-icon.svg';
+import { ReactComponent as ErrorDarkModeIcon } from '@src/assets/not-found-dark-mode-icon.svg';
 import useAuthModal from '@src/Hook/useAuthModal';
 import LoginModal from '@src/components/nav/LoginModal';
 import Signup from '@src/components/Signup';
+import { useRecoilValue } from 'recoil';
+import { isDarkModeState } from '@src/states/darkModeState';
 
 const Login = () => {
-  const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
-  const [isSignUpModalOpen, setIsSignUpModalOpen] = useState(false);
+  const [isLoginModalOpen, setIsLoginModalOpen] = useState<boolean>(false);
+  const [isSignUpModalOpen, setIsSignUpModalOpen] = useState<boolean>(false);
+  const isDarkMode = useRecoilValue<boolean>(isDarkModeState);
 
   const location = useLocation();
 
@@ -23,7 +27,7 @@ const Login = () => {
 
   return (
     <StLogin>
-      <ErrorIcon />
+      {isDarkMode ? <ErrorDarkModeIcon /> : <ErrorIcon />}
       <StTextContainer>
         <StText>로그인 후 이용 가능한 서비스입니다!</StText>
         <StDescription>간편하게 로그인 후 다양한 POL 서비스를 이용해보세요.</StDescription>

--- a/src/shared/ErrorFallback.tsx
+++ b/src/shared/ErrorFallback.tsx
@@ -1,9 +1,13 @@
 import { styled } from 'styled-components';
 import { ReactComponent as ErrorIcon } from '@src/assets/not-found-icon.svg';
+import { ReactComponent as DarkModeErrorIcon } from '@src/assets/not-found-dark-mode-icon.svg';
 import { useNavigate } from 'react-router-dom';
 import { PATH_URL } from '@src/constants/constants';
+import { useRecoilValue } from 'recoil';
+import { isDarkModeState } from '@src/states/darkModeState';
 
 const ErrorFallback = () => {
+  const isDarkMode = useRecoilValue<boolean>(isDarkModeState);
   const navigate = useNavigate();
   const onClickHomeButton = () => {
     navigate(PATH_URL.HOME);
@@ -12,7 +16,7 @@ const ErrorFallback = () => {
 
   return (
     <StErrorFallback>
-      <ErrorIcon />
+      {isDarkMode ? <DarkModeErrorIcon /> : <ErrorIcon />}
       <StTextContainer>
         <StErrorTitle>요청하신 페이지를 찾을 수 없습니다.</StErrorTitle>
         <StErrorDescription>

--- a/src/shared/Header.tsx
+++ b/src/shared/Header.tsx
@@ -16,7 +16,7 @@ interface HeaderProps {
 }
 
 const Header = ({ onClickMobileMenu, setIsInProgressModalOpen }: HeaderProps) => {
-  const isDarkMode = useRecoilValue(isDarkModeState);
+  const isDarkMode = useRecoilValue<boolean>(isDarkModeState);
   const navigate = useNavigate();
   const resetSelectedRecoilValue = useResetSelectedFilterRecoilValues();
 

--- a/src/shared/Nav.tsx
+++ b/src/shared/Nav.tsx
@@ -50,6 +50,7 @@ const StNav = styled.div<{ darkmode: string }>`
   ${commonNavStyle}
   padding: 45px 41px;
   width: 270px;
+  outline: ${({ darkmode }) => (darkmode === 'true' ? '1.5px solid white' : 'none')};
   background-color: ${({ darkmode }) => (darkmode === 'true' ? 'black' : 'white')};
   color: ${({ darkmode }) => (darkmode === 'true' ? 'white' : 'black')};
 `;
@@ -60,6 +61,7 @@ const StMobileNav = styled.div<{ darkmode: string }>`
   width: 85px;
   align-items: center;
   border-bottom-right-radius: 20px;
+  outline: ${({ darkmode }) => (darkmode === 'true' ? '1.5px solid white' : 'none')};
   background-color: ${({ darkmode }) => (darkmode === 'true' ? 'black' : 'white')};
   color: ${({ darkmode }) => (darkmode === 'true' ? 'white' : 'black')};
 `;

--- a/src/style/GlobalStyle.tsx
+++ b/src/style/GlobalStyle.tsx
@@ -8,6 +8,10 @@ const GlobalStyle = createGlobalStyle`
     .darkMode{
       background-color: black;
       color: white;
+
+      input, textarea{
+        color: white;
+      }
     }
   }
 
@@ -18,6 +22,7 @@ const GlobalStyle = createGlobalStyle`
 
   input, textarea{
     font-family: 'SUIT Variable', sans-serif;
+    background-color: inherit;
   }
 `;
 

--- a/src/style/common/commonStyles.ts
+++ b/src/style/common/commonStyles.ts
@@ -77,6 +77,7 @@ export const ModalStyle = {
     border-radius: 30px;
     background-color: white;
     padding: 90px 50px;
+    color: black;
 
     display: flex;
     flex-direction: column;

--- a/src/style/common/createStepStyles.ts
+++ b/src/style/common/createStepStyles.ts
@@ -41,9 +41,10 @@ export const ButtonContainer = styled.div<{ width?: string; margintop?: string }
   }
 `;
 
-export const StInputLabel = styled.div`
+export const StInputLabel = styled.label`
   color: gray;
-  font-size: 13px;
+  font-size: 15px;
+  font-weight: 800;
 `;
 
 export const PersonalInfoStyle = {

--- a/src/style/theme.ts
+++ b/src/style/theme.ts
@@ -12,6 +12,7 @@ const theme: ThemeType = {
     lightGray: '#F3F3F3;',
     paleGray: '#C7C7C7',
     gray: '#E7E7E7',
+    darkModeGray: '#191a1d',
     skyBlue: '#99E7FF',
     errorRed: '#F6685F',
     fontColor: '#3B3B3B',


### PR DESCRIPTION
## 개요
- 포트폴리오 작성 단계 UX 개선
- 전반적 UI 다크모드 고도화
## 작업 사항
- 포트폴리오 작성 단계
  - 한국, 미국 전화번호 형식 select로 선택 후 전화번호 입력 시 자동으로 하이픈 적용
  - 전화번호 입력 시 숫자만 입력 가능하도록 설정
  - 거주지, 희망 근무지역 지역 select 선택 방식으로 변경
  - 유튜브, 블로그 링크, 깃허브 아이디 입력 시 영문, 숫자, 특수문자만 입력 가능하도록 설정
  - 이메일 입력 시 영문,숫자,특수문자(`.`,`-`,`_`)만 입력 가능하도록 설정
  - 정규표현식 관련 코드 분리
  - useOnChangeInput 커스텀 훅 정규표현식 props 전달, 정규표현식 적용
  - 포트폴리오 작성 중 프로젝트 삭제 버튼 클릭 시 경고 모달 추가
- 다크모드 고도화
  - 전역 스타일링으로 적용되지 않는 부분 전반 수정
  - 전역 스타일 다크모드 input, textarea 글자색 white로 설정
  - 전역 스타일 input, textarea `background : inherit`으로 변경